### PR TITLE
Relax Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoSoftDelete.Mixfile do
     [
       app: :ecto_soft_delete,
       version: "2.0.3",
-      elixir: "~> 1.13.4",
+      elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
I think https://github.com/revelrylabs/ecto_soft_delete/pull/154 unintentionally locked down the Elixir version to 1.13.

After the latest update we get warning: the dependency :ecto_soft_delete requires Elixir "~> 1.13.4" but you are running on v1.16.2